### PR TITLE
Add option to hide empty widgets

### DIFF
--- a/plugin.video.seren/resources/language/resource.language.ar_sa/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.ar_sa/strings.po
@@ -4041,3 +4041,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.da_DK/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.da_DK/strings.po
@@ -4037,3 +4037,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.de_de/strings.po
@@ -4088,3 +4088,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.el_gr/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.el_gr/strings.po
@@ -4088,3 +4088,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.en_gb/strings.po
@@ -4091,3 +4091,8 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.es_ES/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.es_ES/strings.po
@@ -4079,3 +4079,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.es_MX/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.es_MX/strings.po
@@ -4079,3 +4079,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.fr_fr/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.fr_fr/strings.po
@@ -4079,3 +4079,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.he_il/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.he_il/strings.po
@@ -3983,3 +3983,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.it_it/strings.po
@@ -4074,3 +4074,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.nl_NL/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.nl_NL/strings.po
@@ -4071,3 +4071,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/language/resource.language.pl_PL/strings.po
+++ b/plugin.video.seren/resources/language/resource.language.pl_PL/strings.po
@@ -4066,3 +4066,7 @@ msgstr "Scrape TorBox Cloud"
 msgctxt "#30730"
 msgid "Enable TorBox Hosters"
 msgstr "Enable TorBox Hosters"
+#: /resources/settings.xml
+msgctxt "#30731"
+msgid "Hide Empty Widgets"
+msgstr "Hide Empty Widgets"

--- a/plugin.video.seren/resources/lib/modules/globals.py
+++ b/plugin.video.seren/resources/lib/modules/globals.py
@@ -1588,11 +1588,12 @@ class GlobalVariables:
 
     def cancel_directory(self):
         if g.FROM_WIDGET:
-            g.add_directory_item(
-                g.get_language_string(284, addon=False),
-                menu_item=g.create_icon_dict("trakt_sync", base_path=g.ICONS_PATH),
-            )
-            xbmcplugin.setContent(self.PLUGIN_HANDLE, g.CONTENT_MENU)
+            if not g.ADDON.getSettingBool("general.widget.hide_empty"):
+                g.add_directory_item(
+                    g.get_language_string(284, addon=False),
+                    menu_item=g.create_icon_dict("trakt_sync", base_path=g.ICONS_PATH),
+                )
+                xbmcplugin.setContent(self.PLUGIN_HANDLE, g.CONTENT_MENU)
             xbmcplugin.endOfDirectory(self.PLUGIN_HANDLE, succeeded=True, cacheToDisc=False)
         else:
             xbmcplugin.endOfDirectory(self.PLUGIN_HANDLE, succeeded=False, cacheToDisc=False)

--- a/plugin.video.seren/resources/settings.xml
+++ b/plugin.video.seren/resources/settings.xml
@@ -50,6 +50,11 @@
 					<default>false</default>
 					<control type="toggle"/>
 				</setting>
+				<setting id="general.widget.hide_empty" type="boolean" label="30731" help="">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
 			</group>
 			<group id="2" label="30592">
 				<setting id="general.flatten.episodes" type="boolean" label="30208" help="">


### PR DESCRIPTION
Hey Goldenfreddy0703. Huge thanks to you, drinfernoo, bbviking, and others for keeping Seren alive.

This PR aims to add a quality of life change by adding a toggle to hide empty widgets when no content is inside them.

I think TMDB Helper has this behavior by default.

### Before:

<p><img width="800" alt="image" src="https://github.com/user-attachments/assets/ef0206d9-e23e-44e3-8493-9fcf532978a3" /></p>

<p><img width="2560" height="1598" alt="image" src="https://github.com/user-attachments/assets/53b42d21-29bf-4799-ad86-238ce273368c" /></p>



### After:

<p><img width="2560" height="1598" alt="image" src="https://github.com/user-attachments/assets/af95eca2-7ae8-4ed7-aea3-5c34cd9f1250" /></p>


A widget refresh / skin reload is needed for changes to take effect.