### PR TITLE
bugfix: Updating the _get_imdb_info to properly account for None

### DIFF
--- a/plugin.video.prism/resources/lib/modules/getSources.py
+++ b/plugin.video.prism/resources/lib/modules/getSources.py
@@ -356,8 +356,9 @@ class Sources:
 
         try:
             resp = self._imdb_suggestions(imdb_id)
-            year = resp.get('y', self.item_information['info']['year'])
-            if year is not None and year != self.item_information['info']['year']:
+            existing_year = self.item_information['info'].get('year')
+            year = resp.get('y', existing_year)
+            if year is not None and year != existing_year:
                 self.item_information['info']['year'] = str(year)
         except requests.exceptions.ConnectionError as ce:
             g.log("Unable to obtain IMDB suggestions to confirm movie year", "warning")


### PR DESCRIPTION
## Summary
Fixes an unhandled `KeyError: 'year'` crash in `getSources.py` that occurs when a title's metadata (`item_information['info']`) is missing a `year` key. This can happen for titles where Simkl/upstream metadata enrichment didn't populate the field.

## Problem
In `_get_imdb_info()`, the fallback value passed to `resp.get('y', ...)` is evaluated eagerly using direct dict indexing:

```python
year = resp.get('y', self.item_information['info']['year'])
```

If `'year'` isn't present in `item_information['info']`, this raises `KeyError` immediately — before `resp.get()` even runs. The surrounding `try/except` only catches `requests.exceptions.ConnectionError`, so this exception is unhandled and crashes playback entirely.

### Reproduction
Confirmed via Kodi log — repeated, consistent crash on the same title across multiple playback attempts:

```
File "...\getSources.py", line 359, in _get_imdb_info
    year = resp.get('y', self.item_information['info']['year'])
KeyError: 'year'
```

## Fix
Switch to `.get('year')` so a missing key returns `None` instead of raising:

```python
existing_year = self.item_information['info'].get('year')
year = resp.get('y', existing_year)
if year is not None and year != existing_year:
    self.item_information['info']['year'] = str(year)
```

This preserves existing behavior when `year` is present, and degrades gracefully (skips the year-correction step) when it isn't, instead of crashing the entire source-lookup flow.

## Testing
- Reproduced the crash locally against the affected title before the patch.
- Applied the fix, cleared cache, restarted Kodi, and confirmed playback no longer throws `KeyError` for the same title.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)